### PR TITLE
Already integrated in pull request 189 by @andrepatta

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -37,7 +37,7 @@
 
 #define CRYPTONOTE_MAX_BLOCK_NUMBER                     500000000
 #define CRYPTONOTE_MAX_BLOCK_SIZE                       500000000  // block header blob limit, never used!
-#define CRYPTONOTE_GETBLOCKTEMPLATE_MAX_BLOCK_SIZE	196608 //size of block (bytes) that is the maximum that miners will produce
+#define CRYPTONOTE_GETBLOCKTEMPLATE_MAX_BLOCK_SIZE      196608 //size of block (bytes) that is the maximum that miners will produce
 #define CRYPTONOTE_MAX_TX_SIZE                          1000000000
 #define CRYPTONOTE_PUBLIC_ADDRESS_TEXTBLOB_VER          0
 #define CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW            18
@@ -54,16 +54,26 @@
 #define EMISSION_SPEED_FACTOR_PER_MINUTE                (20)
 #define FINAL_SUBSIDY_PER_MINUTE                        ((uint64_t)30) // 3 * pow(10, 1)
 
-#define CRYPTONOTE_REWARD_BLOCKS_WINDOW                 100
-#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2    60000 //size of block (bytes) after which reward for block calculated using block size
-#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V1    20000 //size of block (bytes) after which reward for block calculated using block size - before first fork
-#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5    300000 //size of block (bytes) after which reward for block calculated using block size - second change, from v5
+#define CRYPTONOTE_REWARD_BLOCKS_WINDOW                     100
+#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2_OLD    60000 //size of block (bytes) after which reward for block calculated using block size
+#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V1_OLD    20000 //size of block (bytes) after which reward for block calculated using block size - before first fork
+#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5_OLD    300000 //size of block (bytes) after which reward for block calculated using block size - second change, from v5
+
+//default blocksize to 250kB
+#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2    250000 //size of block (bytes) after which reward for block calculated using block size
+#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V1    250000 //size of block (bytes) after which reward for block calculated using block size - before first fork
+#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5    250000 //size of block (bytes) after which reward for block calculated using block size - second change, from v5
+
 #define CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE          600
 #define CRYPTONOTE_DISPLAY_DECIMAL_POINT                2
+
 // COIN - number of smallest units in one coin
 #define COIN                                            ((uint64_t)1000000000000) // pow(10, 12)
 
-#define FEE_PER_KB                                      ((uint64_t)1)
+//tx fee to 0.15 per kB, still reasonable amount.
+#define FEE_PER_KB_OLD_SPAMMED                          ((uint64_t)1)
+#define FEE_PER_KB                                      ((uint64_t)15)
+#define FEE_PER_KB_ANTI_SPAM_PROOF                      ((uint64_t)30)
 #define DYNAMIC_FEE_PER_KB_BASE_FEE                     ((uint64_t)2000000000) // 2 * pow(10,9)
 #define DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD            ((uint64_t)10000000000000) // 10 * pow(10,12)
 #define DYNAMIC_FEE_PER_KB_BASE_FEE_V5                  ((uint64_t)2000000000 * (uint64_t)CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2 / CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5)
@@ -91,7 +101,7 @@
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              20     //by default, blocks count in blocks downloading
 #define CRYPTONOTE_PROTOCOL_HOP_RELAX_COUNT             3      //value of hop, after which we use only announce of new block
 
-#define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    86400 //seconds, one day
+#define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    (86400*3) //seconds, three days
 #define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME     604800 //seconds, one week
 
 #define COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT           1000

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -60,9 +60,9 @@
 #define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5_OLD    300000 //size of block (bytes) after which reward for block calculated using block size - second change, from v5
 
 //default blocksize to 250kB
-#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2    250000 //size of block (bytes) after which reward for block calculated using block size
-#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V1    250000 //size of block (bytes) after which reward for block calculated using block size - before first fork
-#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5    250000 //size of block (bytes) after which reward for block calculated using block size - second change, from v5
+#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2    100000 //size of block (bytes) after which reward for block calculated using block size
+#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V1    100000 //size of block (bytes) after which reward for block calculated using block size - before first fork
+#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5    100000 //size of block (bytes) after which reward for block calculated using block size - second change, from v5
 
 #define CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE          600
 #define CRYPTONOTE_DISPLAY_DECIMAL_POINT                2
@@ -73,7 +73,7 @@
 //tx fee to 0.15 per kB, still reasonable amount.
 #define FEE_PER_KB_OLD_SPAMMED                          ((uint64_t)1)
 #define FEE_PER_KB                                      ((uint64_t)15)
-#define FEE_PER_KB_ANTI_SPAM_PROOF                      ((uint64_t)30)
+#define FEE_PER_KB_ANTI_SPAM_PROOF                      ((uint64_t)45)
 #define DYNAMIC_FEE_PER_KB_BASE_FEE                     ((uint64_t)2000000000) // 2 * pow(10,9)
 #define DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD            ((uint64_t)10000000000000) // 10 * pow(10,12)
 #define DYNAMIC_FEE_PER_KB_BASE_FEE_V5                  ((uint64_t)2000000000 * (uint64_t)CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2 / CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5)

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -55,9 +55,6 @@
 #define FINAL_SUBSIDY_PER_MINUTE                        ((uint64_t)30) // 3 * pow(10, 1)
 
 #define CRYPTONOTE_REWARD_BLOCKS_WINDOW                     100
-#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2_OLD    60000 //size of block (bytes) after which reward for block calculated using block size
-#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V1_OLD    20000 //size of block (bytes) after which reward for block calculated using block size - before first fork
-#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5_OLD    300000 //size of block (bytes) after which reward for block calculated using block size - second change, from v5
 
 //default blocksize to 250kB
 #define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2    100000 //size of block (bytes) after which reward for block calculated using block size
@@ -71,7 +68,6 @@
 #define COIN                                            ((uint64_t)1000000000000) // pow(10, 12)
 
 //tx fee to 0.15 per kB, still reasonable amount.
-#define FEE_PER_KB_OLD_SPAMMED                          ((uint64_t)1)
 #define FEE_PER_KB                                      ((uint64_t)15)
 #define FEE_PER_KB_ANTI_SPAM_PROOF                      ((uint64_t)45)
 #define DYNAMIC_FEE_PER_KB_BASE_FEE                     ((uint64_t)2000000000) // 2 * pow(10,9)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2269,6 +2269,11 @@ bool Blockchain::check_tx_inputs(transaction& tx, uint64_t& max_used_block_heigh
     {
       size_t ring_size = tx.vin[0].type() == typeid(txin_to_key) ? boost::get<txin_to_key>(tx.vin[0]).key_offsets.size() : 0;
       MINFO("HASH: " << "-" << " I/M/O: " << tx.vin.size() << "/" << ring_size << "/" << tx.vout.size() << " H: " << 0 << " chcktx: " << a);
+
+      if(ring_size > 16){
+        MINFO("ring size greater than 16, rejecting tx");
+        return false;
+      }
     }
     return true;
   }
@@ -2281,6 +2286,11 @@ bool Blockchain::check_tx_inputs(transaction& tx, uint64_t& max_used_block_heigh
   {
     size_t ring_size = tx.vin[0].type() == typeid(txin_to_key) ? boost::get<txin_to_key>(tx.vin[0]).key_offsets.size() : 0;
     MINFO("HASH: " <<  get_transaction_hash(tx) << " I/M/O: " << tx.vin.size() << "/" << ring_size << "/" << tx.vout.size() << " H: " << max_used_block_height << " ms: " << a + m_fake_scan_time << " B: " << get_object_blobsize(tx));
+
+    if(ring_size > 16){
+      MINFO("ring size greater than 16, rejecting tx");
+      return false;
+    }
   }
   if (!res)
     return false;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2257,8 +2257,8 @@ bool Blockchain::check_tx_inputs(transaction& tx, uint64_t& max_used_block_heigh
 
   size_t mixin = tx.vin[0].type() == typeid(txin_to_key) ? boost::get<txin_to_key>(tx.vin[0]).key_offsets.size() : 0;
   //reject tx with mixin over 16 when blockheight is > 250000
-  if(ring_size > 16 && m_db->height() > 250000){
-    LOG_PRINT_L1("tx " << ring_size << " ring size greater than 16, rejecting tx");
+  if(mixin > 16 && m_db->height() > 250000){
+    LOG_PRINT_L1("tx " << mixin << " ring size greater than 16, rejecting tx");
     return false;
   }
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2271,7 +2271,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, uint64_t& max_used_block_heigh
       MINFO("HASH: " << "-" << " I/M/O: " << tx.vin.size() << "/" << ring_size << "/" << tx.vout.size() << " H: " << 0 << " chcktx: " << a);
 
       if(ring_size > 16){
-        MINFO("ring size greater than 16, rejecting tx");
+        MERROR_VER("tx " << ring_size << " ring size greater than 16, rejecting tx");
         return false;
       }
     }
@@ -2288,7 +2288,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, uint64_t& max_used_block_heigh
     MINFO("HASH: " <<  get_transaction_hash(tx) << " I/M/O: " << tx.vin.size() << "/" << ring_size << "/" << tx.vout.size() << " H: " << max_used_block_height << " ms: " << a + m_fake_scan_time << " B: " << get_object_blobsize(tx));
 
     if(ring_size > 16){
-      MINFO("ring size greater than 16, rejecting tx");
+      MERROR_VER("tx " << ring_size << " ring size greater than 16, rejecting tx");
       return false;
     }
   }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2270,8 +2270,9 @@ bool Blockchain::check_tx_inputs(transaction& tx, uint64_t& max_used_block_heigh
       size_t ring_size = tx.vin[0].type() == typeid(txin_to_key) ? boost::get<txin_to_key>(tx.vin[0]).key_offsets.size() : 0;
       MINFO("HASH: " << "-" << " I/M/O: " << tx.vin.size() << "/" << ring_size << "/" << tx.vout.size() << " H: " << 0 << " chcktx: " << a);
 
-      if(ring_size > 16){
-        MERROR_VER("tx " << ring_size << " ring size greater than 16, rejecting tx");
+      //reject tx with mixin over 16 when blockheight is > 250000
+      if(ring_size > 16 && m_db->height() > 250000){
+        LOG_PRINT_L1("tx " << ring_size << " ring size greater than 16, rejecting tx");
         return false;
       }
     }
@@ -2287,8 +2288,9 @@ bool Blockchain::check_tx_inputs(transaction& tx, uint64_t& max_used_block_heigh
     size_t ring_size = tx.vin[0].type() == typeid(txin_to_key) ? boost::get<txin_to_key>(tx.vin[0]).key_offsets.size() : 0;
     MINFO("HASH: " <<  get_transaction_hash(tx) << " I/M/O: " << tx.vin.size() << "/" << ring_size << "/" << tx.vout.size() << " H: " << max_used_block_height << " ms: " << a + m_fake_scan_time << " B: " << get_object_blobsize(tx));
 
-    if(ring_size > 16){
-      MERROR_VER("tx " << ring_size << " ring size greater than 16, rejecting tx");
+    //reject tx with mixin over 16 when blockheight is > 250000
+    if(ring_size > 16 && m_db->height() > 250000){
+      LOG_PRINT_L1("tx " << ring_size << " ring size greater than 16, rejecting tx");
       return false;
     }
   }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -505,6 +505,10 @@ bool simple_wallet::set_default_ring_size(const std::vector<std::string> &args/*
       fail_msg_writer() << tr("ring size must be an integer >= 3");
       return true;
     }
+    if(ring_size > 16){
+      fail_msg_writer() << tr("max ring size allowed is 16");
+      return true;
+    }
     if (ring_size == 0)
       ring_size = DEFAULT_MIX + 1;
  
@@ -2335,9 +2339,8 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
     }
     else
     {
-      //limit ring size to prevent too high mixin tx's
-      if(ring_size > 64){
-        fail_msg_writer() << tr("Ring size too high, max 64");
+      if(ring_size > 16){
+        fail_msg_writer() << tr("Ring size too high, max 16");
         return false;
       }
       else{
@@ -2919,8 +2922,14 @@ bool simple_wallet::sweep_main(uint64_t below, const std::vector<std::string> &a
     }
     else
     {
-      fake_outs_count = ring_size - 1;
-      local_args.erase(local_args.begin());
+      if(ring_size > 16){
+        fail_msg_writer() << tr("Ring size too high, max 16");
+        return false;
+      }
+      else{
+        fake_outs_count = ring_size - 1;
+        local_args.erase(local_args.begin());
+      }
     }
   }
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2326,6 +2326,7 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
   size_t fake_outs_count;
   if(local_args.size() > 0) {
     size_t ring_size;
+
     if(!epee::string_tools::get_xtype_from_string(ring_size, local_args[0]))
     {
       fake_outs_count = m_wallet->default_mixin();
@@ -2334,8 +2335,15 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
     }
     else
     {
-      fake_outs_count = ring_size - 1;
-      local_args.erase(local_args.begin());
+      //limit ring size to prevent too high mixin tx's
+      if((ring_size - 1) > 64){
+        fail_msg_writer() << tr("Ring size too high, max 64");
+        return false;
+      }
+      else{
+        fake_outs_count = ring_size - 1;
+        local_args.erase(local_args.begin());
+      }
     }
   }
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2336,7 +2336,7 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
     else
     {
       //limit ring size to prevent too high mixin tx's
-      if((ring_size - 1) > 64){
+      if(ring_size > 64){
         fail_msg_writer() << tr("Ring size too high, max 64");
         return false;
       }

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -911,6 +911,13 @@ PendingTransaction *WalletImpl::createTransaction(const string &dst_addr, const 
     PendingTransactionImpl * transaction = new PendingTransactionImpl(*this);
 
     do {
+
+        if(fake_outs_count > 16){
+            m_status = Status_Error;
+            m_errorString = tr("Ring size too high, max 16");
+            break;
+        }
+
         if(!cryptonote::get_account_integrated_address_from_str(addr, has_payment_id, payment_id_short, m_wallet->testnet(), dst_addr)) {
             // TODO: copy-paste 'if treating as an address fails, try as url' from simplewallet.cpp:1982
             m_status = Status_Error;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -470,6 +470,11 @@ namespace tools
     try
     {
       uint64_t mixin = adjust_mixin(req.mixin);
+
+      if(mixin > 16){
+        return false;
+      }
+
       std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, req.unlock_time, req.priority, extra, m_trusted_daemon);
 
       // reject proposed transactions if there are more than one.  see on_transfer_split below.


### PR DESCRIPTION
Done: fee per kB to 0.15 (still a reasonable amount considering current exchange rate), mempool lifetime to 3 days to prevent old transactions getting dropped off (good for 3rd party services), default blocksize to 100 kB to increase possible TX/s on the network by default

TODO: Make the blocksize increment faster to provide better scalability, maybe limit the mixin to a reasonable amount to prevent blocks getting filled up to fast with high mixin transactions

I will create a seperate pull request once I got all changes going (later the day, got work to do right now)