### PR TITLE
Fix for visual glitch when executing daemon status command.

### DIFF
--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -421,7 +421,7 @@ bool t_rpc_command_executor::show_status() {
   }
 
   std::time_t uptime = std::time(nullptr) - ires.start_time;
-  uint64_t net_height = ((ires.target_height > ires.height ? ires.target_height : ires.height) - 1);
+  uint64_t net_height = ires.target_height > ires.height ? ires.target_height : ires.height;
 
   tools::success_msg_writer() << boost::format("Height: %llu/%llu (%.1f%%) on %s, %s, net hash %s, v%u%s, %s, %u(out)+%u(in) connections, uptime %ud %uh %um %us")
     % (unsigned long long)ires.height


### PR DESCRIPTION
This change fixes a visual glitch when executing "status" command on daemon in which as returning wrong information about blockchain height (X/X-1 issue).