### PR TITLE
daemon-rpc: add version information to daemon rpc /getinfo

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -152,6 +152,14 @@ namespace cryptonote
     res.block_size_limit = m_core.get_blockchain_storage().get_current_cumulative_blocksize_limit();
     res.status = CORE_RPC_STATUS_OK;
     res.start_time = (uint64_t)m_core.get_start_time();
+
+
+
+
+    res.daemon_release_name = ELECTRONEUM_RELEASE_NAME;
+    res.daemon_version = ELECTRONEUM_VERSION;
+    res.daemon_version_full = ELECTRONEUM_VERSION_FULL;
+    res.daemon_version_tag = ELECTRONEUM_VERSION_TAG;
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -1311,6 +1319,11 @@ namespace cryptonote
     res.block_size_limit = m_core.get_blockchain_storage().get_current_cumulative_blocksize_limit();
     res.status = CORE_RPC_STATUS_OK;
     res.start_time = (uint64_t)m_core.get_start_time();
+
+    res.daemon_release_name = ELECTRONEUM_RELEASE_NAME;
+    res.daemon_version = ELECTRONEUM_VERSION;
+    res.daemon_version_full = ELECTRONEUM_VERSION_FULL;
+    res.daemon_version_tag = ELECTRONEUM_VERSION_TAG;
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -572,6 +572,11 @@ namespace cryptonote
       uint64_t block_size_limit;
       uint64_t start_time;
 
+      std::string daemon_release_name;
+      std::string daemon_version;
+      std::string daemon_version_full;
+      std::string daemon_version_tag;
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(status)
         KV_SERIALIZE(height)
@@ -590,6 +595,11 @@ namespace cryptonote
         KV_SERIALIZE(cumulative_difficulty)
         KV_SERIALIZE(block_size_limit)
         KV_SERIALIZE(start_time)
+
+        KV_SERIALIZE(daemon_release_name)
+        KV_SERIALIZE(daemon_version)
+        KV_SERIALIZE(daemon_version_full)
+        KV_SERIALIZE(daemon_version_tag)
       END_KV_SERIALIZE_MAP()
     };
   };


### PR DESCRIPTION
This patch adds the version information to the Daemon RPC "getinfo" method.