### PR TITLE
wallet-rpc: new relay_tx method

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -47,12 +47,27 @@ namespace cryptonote
     std::vector<output_entry> outputs;  //index + key + optional ringct commitment
     size_t real_output;                 //index in outputs vector of real output_entry
     crypto::public_key real_out_tx_key; //incoming real tx public key
+    std::vector<crypto::public_key> real_out_additional_tx_keys; //incoming real tx additional public keys
     size_t real_output_in_tx_index;     //index in transaction outputs vector
     uint64_t amount;                    //money
     bool rct;                           //true if the output is rct
     rct::key mask;                      //ringct amount mask
 
     void push_output(uint64_t idx, const crypto::public_key &k, uint64_t amount) { outputs.push_back(std::make_pair(idx, rct::ctkey({rct::pk2rct(k), rct::zeroCommit(amount)}))); }
+
+    BEGIN_SERIALIZE_OBJECT()
+      FIELD(outputs)
+      FIELD(real_output)
+      FIELD(real_out_tx_key)
+      FIELD(real_out_additional_tx_keys)
+      FIELD(real_output_in_tx_index)
+      FIELD(amount)
+      FIELD(rct)
+      FIELD(mask)
+
+      if (real_output >= outputs.size())
+        return false;
+    END_SERIALIZE()
   };
 
   struct tx_destination_entry

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1228,7 +1228,8 @@ bool t_rpc_command_executor::start_save_graph()
 			return true;
 		}
 	}
-	
+
+  tools::success_msg_writer() << "Saving graph is now on";	
 	return true;
 }
 
@@ -1254,6 +1255,8 @@ bool t_rpc_command_executor::stop_save_graph()
 			return true;
 		}
 	}
+
+  tools::success_msg_writer() << "Saving graph is now off";
 	return true;
 }
 
@@ -1420,6 +1423,7 @@ bool t_rpc_command_executor::flush_txpool(const std::string &txid)
         }
     }
 
+    tools::success_msg_writer() << "Pool successfully flushed";
     return true;
 }
 
@@ -1726,6 +1730,7 @@ bool t_rpc_command_executor::relay_tx(const std::string &txid)
         }
     }
 
+    tools::success_msg_writer() << "Transaction successfully relayed";
     return true;
 }
 

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -43,6 +43,8 @@
 #pragma once
 #include <vector>
 #include <list>
+#include <set>
+#include <unordered_set>
 #include <string>
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/integral_constant.hpp>
@@ -348,3 +350,4 @@ namespace serialization {
 #include "vector.h"
 #include "list.h"
 #include "pair.h"
+#include "set.h"

--- a/src/serialization/set.h
+++ b/src/serialization/set.h
@@ -1,0 +1,127 @@
+// Copyright (c) 2014-2017, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
+
+#pragma once
+
+#include "serialization.h"
+
+template <template <bool> class Archive, class T>
+bool do_serialize(Archive<false> &ar, std::set<T> &v);
+template <template <bool> class Archive, class T>
+bool do_serialize(Archive<true> &ar, std::set<T> &v);
+template <template <bool> class Archive, class T>
+bool do_serialize(Archive<false> &ar, std::unordered_set<T> &v);
+template <template <bool> class Archive, class T>
+bool do_serialize(Archive<true> &ar, std::unordered_set<T> &v);
+
+namespace serialization
+{
+  namespace detail
+  {
+    template <typename Archive, class T>
+    bool serialize_set_element(Archive& ar, T& e)
+    {
+      return ::do_serialize(ar, e);
+    }
+
+    template <typename Archive>
+    bool serialize_set_element(Archive& ar, uint32_t& e)
+    {
+      ar.serialize_varint(e);
+      return true;
+    }
+
+    template <typename Archive>
+    bool serialize_set_element(Archive& ar, uint64_t& e)
+    {
+      ar.serialize_varint(e);
+      return true;
+    }
+  }
+}
+
+template <template <bool> class Archive, class T>
+bool do_serialize_set(Archive<false> &ar, T &v)
+{
+  size_t cnt;
+  ar.begin_array(cnt);
+  if (!ar.stream().good())
+    return false;
+  v.clear();
+
+  // very basic sanity check
+  if (ar.remaining_bytes() < cnt) {
+    ar.stream().setstate(std::ios::failbit);
+    return false;
+  }
+
+  for (size_t i = 0; i < cnt; i++) {
+    if (i > 0)
+      ar.delimit_array();
+    typename T::key_type k;
+    if (!::serialization::detail::serialize_set_element(ar, k))
+      return false;
+    v.insert(std::move(k));
+    if (!ar.stream().good())
+      return false;
+  }
+  ar.end_array();
+  return true;
+}
+
+template <template <bool> class Archive, class T>
+bool do_serialize_set(Archive<true> &ar, T &v)
+{
+  size_t cnt = v.size();
+  ar.begin_array(cnt);
+  bool first = true;
+  for (const typename T::key_type &k: v) {
+    if (!ar.stream().good())
+      return false;
+    if (!first)
+      ar.delimit_array();
+    if(!::serialization::detail::serialize_set_element(ar, const_cast<typename T::key_type&>(k)))
+      return false;
+    if (!ar.stream().good())
+      return false;
+    first = false;
+  }
+  ar.end_array();
+  return true;
+}
+
+template <template <bool> class Archive, class T>
+bool do_serialize(Archive<false> &ar, std::set<T> &v) { return do_serialize_set(ar, v); }
+template <template <bool> class Archive, class T>
+bool do_serialize(Archive<true> &ar, std::set<T> &v) { return do_serialize_set(ar, v); }
+template <template <bool> class Archive, class T>
+bool do_serialize(Archive<false> &ar, std::unordered_set<T> &v) { return do_serialize_set(ar, v); }
+template <template <bool> class Archive, class T>
+bool do_serialize(Archive<true> &ar, std::unordered_set<T> &v) { return do_serialize_set(ar, v); }

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -219,6 +219,17 @@ namespace tools
       uint64_t unlock_time;
       bool use_rct;
       std::vector<cryptonote::tx_destination_entry> dests; // original setup, does not include change
+
+      BEGIN_SERIALIZE_OBJECT()
+        FIELD(sources)
+        FIELD(change_dts)
+        FIELD(splitted_dsts)
+        FIELD(selected_transfers)
+        FIELD(extra)
+        FIELD(unlock_time)
+        FIELD(use_rct)
+        FIELD(dests)
+      END_SERIALIZE()
     };
 
     typedef std::vector<transfer_details> transfer_container;
@@ -236,9 +247,24 @@ namespace tools
       std::list<size_t> selected_transfers;
       std::string key_images;
       crypto::secret_key tx_key;
+        std::vector<crypto::secret_key> additional_tx_keys;
       std::vector<cryptonote::tx_destination_entry> dests;
 
       tx_construction_data construction_data;
+
+      BEGIN_SERIALIZE_OBJECT()
+        FIELD(tx)
+        FIELD(dust)
+        FIELD(fee)
+        FIELD(dust_added_to_fee)
+        FIELD(change_dts)
+        FIELD(selected_transfers)
+        FIELD(key_images)
+        FIELD(tx_key)
+        FIELD(additional_tx_keys)
+        FIELD(dests)
+        FIELD(construction_data)
+      END_SERIALIZE()
     };
 
     // The term "Unsigned tx" is not really a tx since it's not signed yet.

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -31,6 +31,7 @@
 #include <boost/format.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <boost/algorithm/string.hpp>
 #include <cstdint>
 #include "include_base_utils.h"
 using namespace epee;
@@ -485,6 +486,13 @@ namespace tools
         tx_to_blob(ptx_vector.back().tx, blob);
         res.tx_blob = epee::string_tools::buff_to_hex_nodelimer(blob);
       }
+      if (req.get_tx_metadata)
+      {
+        std::ostringstream oss;
+        binary_archive<true> ar(oss);
+        ::serialization::serialize(ar, ptx_vector.back());
+        res.tx_metadata = epee::string_tools::buff_to_hex_nodelimer(oss.str());
+      }
       return true;
     }
 
@@ -539,7 +547,7 @@ namespace tools
       }
 
       // populate response with tx hashes
-      for (auto & ptx : ptx_vector)
+      for (const auto & ptx : ptx_vector)
       {
         res.tx_hash_list.push_back(epee::string_tools::pod_to_hex(cryptonote::get_transaction_hash(ptx.tx)));
         if (req.get_tx_keys)
@@ -559,6 +567,13 @@ namespace tools
           cryptonote::blobdata blob;
           tx_to_blob(ptx.tx, blob);
           res.tx_blob_list.push_back(epee::string_tools::buff_to_hex_nodelimer(blob));
+        }
+        if (req.get_tx_metadata)
+        {
+          std::ostringstream oss;
+          binary_archive<true> ar(oss);
+          ::serialization::serialize(ar, const_cast<tools::wallet2::pending_tx&>(ptx));
+          res.tx_metadata_list.push_back(epee::string_tools::buff_to_hex_nodelimer(oss.str()));
         }
       }
 
@@ -597,7 +612,7 @@ namespace tools
         m_wallet->commit_tx(ptx_vector);
 
       // populate response with tx hashes
-      for (auto & ptx : ptx_vector)
+      for (const auto & ptx : ptx_vector)
       {
         res.tx_hash_list.push_back(epee::string_tools::pod_to_hex(cryptonote::get_transaction_hash(ptx.tx)));
         if (req.get_tx_keys)
@@ -610,6 +625,13 @@ namespace tools
           cryptonote::blobdata blob;
           tx_to_blob(ptx.tx, blob);
           res.tx_blob_list.push_back(epee::string_tools::buff_to_hex_nodelimer(blob));
+        }
+        if (req.get_tx_metadata)
+        {
+          std::ostringstream oss;
+          binary_archive<true> ar(oss);
+          ::serialization::serialize(ar, const_cast<tools::wallet2::pending_tx&>(ptx));
+          res.tx_metadata_list.push_back(epee::string_tools::buff_to_hex_nodelimer(oss.str()));
         }
       }
 
@@ -662,7 +684,7 @@ namespace tools
         m_wallet->commit_tx(ptx_vector);
 
       // populate response with tx hashes
-      for (auto & ptx : ptx_vector)
+      for (const auto & ptx : ptx_vector)
       {
         res.tx_hash_list.push_back(epee::string_tools::pod_to_hex(cryptonote::get_transaction_hash(ptx.tx)));
         if (req.get_tx_keys)
@@ -674,6 +696,13 @@ namespace tools
           cryptonote::blobdata blob;
           tx_to_blob(ptx.tx, blob);
           res.tx_blob_list.push_back(epee::string_tools::buff_to_hex_nodelimer(blob));
+        }
+        if (req.get_tx_metadata)
+        {
+          std::ostringstream oss;
+          binary_archive<true> ar(oss);
+          ::serialization::serialize(ar, const_cast<tools::wallet2::pending_tx&>(ptx));
+          res.tx_metadata_list.push_back(epee::string_tools::buff_to_hex_nodelimer(oss.str()));
         }
       }
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -722,6 +722,41 @@ namespace tools
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool wallet_rpc_server::on_relay_tx(const wallet_rpc::COMMAND_RPC_RELAY_TX::request& req, wallet_rpc::COMMAND_RPC_RELAY_TX::response& res, epee::json_rpc::error& er)
+  {
+    if (!m_wallet) return not_open(er);
+     cryptonote::blobdata blob;
+    if (!epee::string_tools::parse_hexstr_to_binbuff(req.hex, blob))
+    {
+      er.code = WALLET_RPC_ERROR_CODE_BAD_HEX;
+      er.message = "Failed to parse hex.";
+      return false;
+    }
+     std::stringstream ss;
+    ss << blob;
+    binary_archive<false> ba(ss);
+     tools::wallet2::pending_tx ptx;
+    bool r = ::serialization::serialize(ba, ptx);
+    if (!r)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_BAD_TX_METADATA;
+      er.message = "Failed to parse tx metadata.";
+      return false;
+    }
+     try
+    {
+      m_wallet->commit_tx(ptx);
+    }
+    catch(const std::exception &e)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
+      er.message = "Failed to commit tx.";
+      return false;
+    }
+     res.tx_hash = epee::string_tools::pod_to_hex(cryptonote::get_transaction_hash(ptx.tx));
+     return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::on_make_integrated_address(const wallet_rpc::COMMAND_RPC_MAKE_INTEGRATED_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_MAKE_INTEGRATED_ADDRESS::response& res, epee::json_rpc::error& er)
   {
     if (!m_wallet) return not_open(er);

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -74,6 +74,7 @@ namespace tools
         MAP_JON_RPC_WE("transfer_split",     on_transfer_split,     wallet_rpc::COMMAND_RPC_TRANSFER_SPLIT)
         MAP_JON_RPC_WE("sweep_dust",         on_sweep_dust,         wallet_rpc::COMMAND_RPC_SWEEP_DUST)
         MAP_JON_RPC_WE("sweep_all",          on_sweep_all,          wallet_rpc::COMMAND_RPC_SWEEP_ALL)
+        MAP_JON_RPC_WE("relay_tx",           on_relay_tx,           wallet_rpc::COMMAND_RPC_RELAY_TX)
         MAP_JON_RPC_WE("store",              on_store,              wallet_rpc::COMMAND_RPC_STORE)
         MAP_JON_RPC_WE("get_payments",       on_get_payments,       wallet_rpc::COMMAND_RPC_GET_PAYMENTS)
         MAP_JON_RPC_WE("get_bulk_payments",  on_get_bulk_payments,  wallet_rpc::COMMAND_RPC_GET_BULK_PAYMENTS)
@@ -116,6 +117,7 @@ namespace tools
       bool on_transfer_split(const wallet_rpc::COMMAND_RPC_TRANSFER_SPLIT::request& req, wallet_rpc::COMMAND_RPC_TRANSFER_SPLIT::response& res, epee::json_rpc::error& er);
       bool on_sweep_dust(const wallet_rpc::COMMAND_RPC_SWEEP_DUST::request& req, wallet_rpc::COMMAND_RPC_SWEEP_DUST::response& res, epee::json_rpc::error& er);
       bool on_sweep_all(const wallet_rpc::COMMAND_RPC_SWEEP_ALL::request& req, wallet_rpc::COMMAND_RPC_SWEEP_ALL::response& res, epee::json_rpc::error& er);
+      bool on_relay_tx(const wallet_rpc::COMMAND_RPC_RELAY_TX::request& req, wallet_rpc::COMMAND_RPC_RELAY_TX::response& res, epee::json_rpc::error& er);
       bool on_make_integrated_address(const wallet_rpc::COMMAND_RPC_MAKE_INTEGRATED_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_MAKE_INTEGRATED_ADDRESS::response& res, epee::json_rpc::error& er);
       bool on_split_integrated_address(const wallet_rpc::COMMAND_RPC_SPLIT_INTEGRATED_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_SPLIT_INTEGRATED_ADDRESS::response& res, epee::json_rpc::error& er);
       bool on_store(const wallet_rpc::COMMAND_RPC_STORE::request& req, wallet_rpc::COMMAND_RPC_STORE::response& res, epee::json_rpc::error& er);

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -122,6 +122,7 @@ namespace wallet_rpc
       bool get_tx_key;
       bool do_not_relay;
       bool get_tx_hex;
+      bool get_tx_metadata;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
@@ -132,6 +133,7 @@ namespace wallet_rpc
         KV_SERIALIZE(get_tx_key)
         KV_SERIALIZE_OPT(do_not_relay, false)
         KV_SERIALIZE_OPT(get_tx_hex, false)
+        KV_SERIALIZE_OPT(get_tx_metadata, false)
       END_KV_SERIALIZE_MAP()
     };
 
@@ -142,6 +144,7 @@ namespace wallet_rpc
       std::list<std::string> amount_keys;
       uint64_t fee;
       std::string tx_blob;
+      std::string tx_metadata;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash)
@@ -149,6 +152,7 @@ namespace wallet_rpc
         KV_SERIALIZE(amount_keys)
         KV_SERIALIZE(fee)
         KV_SERIALIZE(tx_blob)
+        KV_SERIALIZE(tx_metadata)
       END_KV_SERIALIZE_MAP()
     };
   };
@@ -165,6 +169,7 @@ namespace wallet_rpc
       bool get_tx_keys;
       bool do_not_relay;
       bool get_tx_hex;
+      bool get_tx_metadata;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
@@ -175,6 +180,7 @@ namespace wallet_rpc
         KV_SERIALIZE(get_tx_keys)
         KV_SERIALIZE_OPT(do_not_relay, false)
         KV_SERIALIZE_OPT(get_tx_hex, false)
+        KV_SERIALIZE_OPT(get_tx_metadata, false)
       END_KV_SERIALIZE_MAP()
     };
 
@@ -194,6 +200,7 @@ namespace wallet_rpc
       std::list<uint64_t> amount_list;
       std::list<uint64_t> fee_list;
       std::list<std::string> tx_blob_list;
+      std::list<std::string> tx_metadata_list;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash_list)
@@ -201,6 +208,7 @@ namespace wallet_rpc
         KV_SERIALIZE(amount_list)
         KV_SERIALIZE(fee_list)
         KV_SERIALIZE(tx_blob_list)
+        KV_SERIALIZE(tx_metadata_list)
       END_KV_SERIALIZE_MAP()
     };
   };
@@ -212,11 +220,13 @@ namespace wallet_rpc
       bool get_tx_keys;
       bool do_not_relay;
       bool get_tx_hex;
+      bool get_tx_metadata;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(get_tx_keys)
         KV_SERIALIZE_OPT(do_not_relay, false)
         KV_SERIALIZE_OPT(get_tx_hex, false)
+        KV_SERIALIZE_OPT(get_tx_metadata, false)
       END_KV_SERIALIZE_MAP()
     };
 
@@ -235,12 +245,14 @@ namespace wallet_rpc
       std::list<std::string> tx_key_list;
       std::list<uint64_t> fee_list;
       std::list<std::string> tx_blob_list;
+      std::list<std::string> tx_metadata_list;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash_list)
         KV_SERIALIZE(tx_key_list)
         KV_SERIALIZE(fee_list)
         KV_SERIALIZE(tx_blob_list)
+        KV_SERIALIZE(tx_metadata_list)
       END_KV_SERIALIZE_MAP()
     };
   };
@@ -258,6 +270,7 @@ namespace wallet_rpc
       uint64_t below_amount;
       bool do_not_relay;
       bool get_tx_hex;
+      bool get_tx_metadata;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
@@ -269,6 +282,7 @@ namespace wallet_rpc
         KV_SERIALIZE(below_amount)
         KV_SERIALIZE_OPT(do_not_relay, false)
         KV_SERIALIZE_OPT(get_tx_hex, false)
+        KV_SERIALIZE_OPT(get_tx_metadata, false)
       END_KV_SERIALIZE_MAP()
     };
 
@@ -287,12 +301,14 @@ namespace wallet_rpc
       std::list<std::string> tx_key_list;
       std::list<uint64_t> fee_list;
       std::list<std::string> tx_blob_list;
+      std::list<std::string> tx_metadata_list;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(tx_hash_list)
         KV_SERIALIZE(tx_key_list)
         KV_SERIALIZE(fee_list)
         KV_SERIALIZE(tx_blob_list)
+        KV_SERIALIZE(tx_metadata_list)
       END_KV_SERIALIZE_MAP()
     };
   };

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -313,6 +313,30 @@ namespace wallet_rpc
     };
   };
 
+  struct COMMAND_RPC_RELAY_TX
+  {
+    struct request
+    {
+      std::string hex;
+       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(hex)
+      END_KV_SERIALIZE_MAP()
+    };
+     struct response
+    {
+      std::string tx_hash;
+      std::string tx_key;
+      uint64_t fee;
+      std::string tx_blob;
+       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(tx_hash)
+        KV_SERIALIZE(tx_key)
+        KV_SERIALIZE(fee)
+        KV_SERIALIZE(tx_blob)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
+
   struct COMMAND_RPC_STORE
   {
     struct request


### PR DESCRIPTION
This patch adds the new Wallet RPC method "relay_tx" to relay transactions that were previously created with the "do_not_relay" flag. This method requires the tx_metadata (obtained when calling the transfers command) as input.