### PR TITLE
core: enable fluffy-blocks by default

### DIFF
--- a/src/common/command_line.cpp
+++ b/src/common/command_line.cpp
@@ -138,9 +138,9 @@ namespace command_line
   , "Check for new versions of electroneum: [disabled|notify|download|update]"
   , "notify"
   };
-  const arg_descriptor<bool> arg_fluffy_blocks  = {
-    "fluffy-blocks"
-  , "Relay blocks as fluffy blocks where possible (automatic on testnet)"
+  const arg_descriptor<bool> arg_disable_fluffy_blocks  = {
+    "disable-fluffy-blocks"
+  , "Disable relaying blocks as fluffy blocks where possible"
   , false
   };
 }

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -221,5 +221,5 @@ namespace command_line
   extern const arg_descriptor<uint64_t> arg_show_time_stats;
   extern const arg_descriptor<size_t> arg_block_sync_size;
   extern const arg_descriptor<std::string> arg_check_updates;
-  extern const arg_descriptor<bool> arg_fluffy_blocks;
+  extern const arg_descriptor<bool> arg_disable_fluffy_blocks;
 }

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -165,7 +165,7 @@ namespace cryptonote
     command_line::add_arg(desc, command_line::arg_show_time_stats);
     command_line::add_arg(desc, command_line::arg_block_sync_size);
     command_line::add_arg(desc, command_line::arg_check_updates);
-    command_line::add_arg(desc, command_line::arg_fluffy_blocks);
+    command_line::add_arg(desc, command_line::arg_disable_fluffy_blocks);
 
     // we now also need some of net_node's options (p2p bind arg, for separate data dir)
     command_line::add_arg(desc, nodetool::arg_testnet_p2p_bind_port, false);
@@ -201,7 +201,7 @@ namespace cryptonote
 
     set_enforce_dns_checkpoints(command_line::get_arg(vm, command_line::arg_dns_checkpoints));
     test_drop_download_height(command_line::get_arg(vm, command_line::arg_test_drop_download_height));
-    m_fluffy_blocks_enabled = m_testnet || get_arg(vm, command_line::arg_fluffy_blocks);
+    m_fluffy_blocks_enabled = m_testnet || !get_arg(vm, command_line::arg_disable_fluffy_blocks);
 
     if (command_line::get_arg(vm, command_line::arg_test_drop_download) == true)
       test_drop_download();


### PR DESCRIPTION
This patch enables the fluffy-blocks feature by default. 

Fluffy-blocks optimizes the way that blocks are propagated to the network and reduces the amount of network traffic need to block propagation.